### PR TITLE
feat: dual build compiler and cli

### DIFF
--- a/examples/nuxt/eslint.config.ts
+++ b/examples/nuxt/eslint.config.ts
@@ -1,4 +1,4 @@
-import { baseConfig, Config, defineConfig } from '@surimi/linter-config';
+import { baseConfig, defineConfig, type Config } from '@surimi/linter-config';
 
 const config: Config = defineConfig(baseConfig, {
   ignores: ['**/.nuxt', '**/.output'],

--- a/examples/nuxt/nuxt.config.ts
+++ b/examples/nuxt/nuxt.config.ts
@@ -6,7 +6,7 @@ export default defineNuxtConfig({
   devtools: { enabled: true },
   typescript: {
     tsConfig: {
-      include: ['*.config.ts', 'src'],
+      include: ['*.config.ts', 'src', '../*.config.ts'],
       exclude: ['node_modules', 'dist', '.output'],
     },
   },

--- a/examples/nuxt/package.json
+++ b/examples/nuxt/package.json
@@ -6,7 +6,6 @@
     "build": "nuxt build",
     "dev": "nuxt dev",
     "generate": "nuxt generate",
-    "postinstall": "nuxt prepare",
     "preview": "nuxt preview"
   },
   "dependencies": {

--- a/examples/nuxt/package.json
+++ b/examples/nuxt/package.json
@@ -6,6 +6,7 @@
     "build": "nuxt build",
     "dev": "nuxt dev",
     "generate": "nuxt generate",
+    "postinstall": "nuxt prepare",
     "preview": "nuxt preview"
   },
   "dependencies": {

--- a/packages/compiler/package.json
+++ b/packages/compiler/package.json
@@ -15,13 +15,20 @@
   },
   "exports": {
     ".": {
-      "types": "./dist/index.d.ts",
-      "import": "./dist/index.js"
+      "types": "./dist/index.node.d.ts",
+      "browser": "./dist/index.browser.js",
+      "import": "./dist/index.node.js",
+      "default": "./dist/index.node.js"
+    },
+    "./browser": {
+      "types": "./dist/index.browser.d.ts",
+      "import": "./dist/index.browser.js",
+      "default": "./dist/index.browser.js"
     }
   },
-  "main": "dist/index.js",
-  "module": "dist/index.js",
-  "types": "dist/index.d.ts",
+  "main": "dist/index.node.js",
+  "module": "dist/index.node.js",
+  "types": "dist/index.node.d.ts",
   "bin": {
     "surimi": "./dist/cli.js"
   },
@@ -36,8 +43,8 @@
   },
   "dependencies": {
     "@clack/prompts": "^0.11.0",
-    "@rolldown/browser": "1.0.0-rc.5",
-    "commander": "^14.0.3"
+    "commander": "^14.0.3",
+    "picocolors": "^1.1.1"
   },
   "devDependencies": {
     "@surimi/linter-config": "workspace:*",
@@ -47,6 +54,13 @@
     "typescript": "catalog:build"
   },
   "peerDependencies": {
+    "@rolldown/browser": "1.0.0-rc.9",
+    "rolldown": "1.0.0-rc.9",
     "surimi": "workspace:*"
+  },
+  "peerDependenciesMeta": {
+    "@rolldown/browser": {
+      "optional": true
+    }
   }
 }

--- a/packages/compiler/src/cli.ts
+++ b/packages/compiler/src/cli.ts
@@ -5,9 +5,11 @@ import { basename, dirname, extname, resolve } from 'node:path';
 import process from 'node:process';
 import { cancel, intro, log, note, outro, spinner } from '@clack/prompts';
 import { Command } from 'commander';
+import pc from 'picocolors';
 
-import { compile, compileWatch } from '.';
 import { version } from '../package.json';
+import { compile, compileWatch } from './index.node';
+import type { CompileResult, RolldownWatcherEvent } from './types';
 
 interface CLIOptions {
   input: string;
@@ -35,6 +37,29 @@ function isStringArray(value: unknown): value is string[] {
   return Array.isArray(value) && value.every((entry): entry is string => typeof entry === 'string');
 }
 
+/** Format rolldown/compile errors for display. Preserves rolldown's multi-line boxed message when present. */
+function formatCompileError(error: unknown): string {
+  if (error instanceof Error) {
+    const msg = error.message || String(error);
+    if (msg.includes('\n')) return msg;
+    const stack = error.stack;
+    const firstStackLine = stack?.split('\n')[1]?.trim();
+    if (firstStackLine?.includes(':')) return `${msg}\n  at ${firstStackLine}`;
+    return msg;
+  }
+  return String(error);
+}
+
+function logError(err: unknown) {
+  const msg = formatCompileError(err);
+  log.error(pc.red(msg));
+}
+
+function printIntro() {
+  console.clear();
+  intro(`🍣 @surimi/compiler ${pc.bgCyan(pc.black(` v${version} `))}`);
+  note('Surimi is still in early development. Please report any issues you encounter!', 'Warning: Early Development');
+}
 function generateOutputPaths(inputPath: string, outDir?: string): { css: string; js: string } {
   const parsed = {
     dir: outDir ?? dirname(inputPath),
@@ -90,8 +115,7 @@ async function runCompile(options: CLIOptions) {
   const compileOptions = { input: inputPath, cwd, include, exclude };
 
   try {
-    intro(`🍣 @surimi/compiler (v${version})`);
-    note('Surimi is still in early development. Please report any issues you encounter!', 'Warning: Early Development');
+    printIntro();
 
     const s = spinner();
     const filename = basename(inputPath);
@@ -105,7 +129,8 @@ async function runCompile(options: CLIOptions) {
 
     outro(`Thanks for using surimi! 👋`);
   } catch (error) {
-    cancel(`Compilation failed: ${error instanceof Error ? error.message : String(error)}`);
+    logError(error);
+    cancel('Compilation failed');
     process.exit(1);
   }
 }
@@ -135,7 +160,6 @@ async function runSingleCompile(
     s.stop(`Compilation completed in ${String(result.duration)}ms`);
   } catch (error) {
     s.stop('Compilation failed');
-    log.error(`${error instanceof Error ? error.message : String(error)}\n`);
     throw error;
   }
 }
@@ -150,32 +174,72 @@ async function runWatchMode(
   s: ReturnType<typeof spinner>,
   filename: string,
 ): Promise<void> {
-  s.start(`Watching ${filename}...`);
+  // Initial build so output exists before watching (rolldown watch may not emit BUNDLE_END immediately)
+  s.start(`Compiling ${filename}...`);
+  try {
+    const initialResult = await compile(compileOptions);
+    if (initialResult) {
+      await writeCompilationOutput(initialResult, outputPaths, options);
+      s.message(`✅ Initial build in ${initialResult.duration}ms. Watching...`);
+    } else {
+      s.message(`❌ Initial build failed - Watching...`);
+    }
+  } catch (error) {
+    logError(error);
+    s.message(`❌ Initial build failed - Watching...`);
+  }
 
-  await new Promise<void>(resolve => {
+  await new Promise<void>(_resolve => {
+    let lastWasError = false;
+
     const watcher = compileWatch(compileOptions, {
-      onChange: result => {
-        (async () => {
+      onChange: (result: CompileResult | undefined, _event: RolldownWatcherEvent, error?: unknown) => {
+        void (async () => {
           try {
             if (!result) {
+              s.stop('');
+              printIntro();
+              if (error !== undefined) logError(error);
+              s.start(`Compiling ${filename}...`);
               s.message(`❌ Build failed - Watching...`);
+              lastWasError = true;
               return;
             }
 
             await writeCompilationOutput(result, outputPaths, options);
 
+            if (lastWasError) {
+              s.stop('');
+              printIntro();
+              s.start(`Compiling ${filename}...`);
+            }
+            lastWasError = false;
             s.message(`✅ Compiled in ${result.duration}ms. Watching...`);
-          } catch (error) {
-            log.error(`${error instanceof Error ? error.message : String(error)}\n`);
+          } catch (err) {
+            s.stop('');
+            printIntro();
+            logError(err);
+            s.start(`Compiling ${filename}...`);
             s.message(`❌ Error writing files - Watching...`);
+            lastWasError = true;
           }
-        })().catch(console.error);
+        })().catch((err: unknown) => {
+          s.stop('');
+          printIntro();
+          logError(err);
+          s.start(`Compiling ${filename}...`);
+          s.message(`❌ Build failed - Watching...`);
+          lastWasError = true;
+        });
       },
     });
 
-    // Cleanup function to restore terminal state
-    const cleanup = () => {
+    // Cleanup function to restore terminal state and remove listeners
+    const cleanup = (onKeyPress?: (key: string) => void) => {
       try {
+        if (onKeyPress && process.stdin.isTTY) {
+          process.stdin.off('data', onKeyPress);
+        }
         if (process.stdin.isTTY) {
           process.stdin.setRawMode(false);
           process.stdin.pause();
@@ -205,12 +269,10 @@ async function runWatchMode(
         if (key === 'q' || key === '\u0003') {
           // 'q' or Ctrl+C
           s.stop('ℹ Exiting watch mode...');
-          cleanup();
+          cleanup(onKeyPress);
           watcher
             .close()
-            .then(() => {
-              resolve();
-            })
+            .then(() => process.exit(0))
             .catch(console.error);
         }
       };
@@ -271,6 +333,6 @@ async function main() {
 }
 
 main().catch((error: unknown) => {
-  log.error(`Error: ${error instanceof Error ? error.message : String(error)}`);
+  logError(error);
   process.exit(1);
 });

--- a/packages/compiler/src/compile-api.ts
+++ b/packages/compiler/src/compile-api.ts
@@ -1,0 +1,118 @@
+import { getCompileResult, getRolldownInput } from './compiler';
+import type { CompileOptions, CompileResult, RolldownWatcherEvent, WatchOptions } from './types';
+
+/**
+ * Minimal rolldown API used by compile/compileWatch.
+ * Callers pass { rolldown, watch } from 'rolldown' or '@rolldown/browser'; we type as unknown to avoid pulling in package-specific types.
+ */
+export interface RolldownApi {
+  rolldown: (input: unknown) => Promise<{
+    generate(): Promise<{
+      output: Array<{ code: string; imports: string[]; dynamicImports: string[]; moduleIds: string[] }>;
+    }>;
+  }>;
+  watch: (opts: unknown) => {
+    on(event: string, listener: (e: RolldownWatcherEvent) => void | Promise<void>): unknown;
+    close(): Promise<void>;
+  };
+}
+
+export function createCompile(api: RolldownApi) {
+  async function compile(options: CompileOptions): Promise<CompileResult | undefined> {
+    const startTime = Date.now();
+    const input = getRolldownInput(options);
+    const rolldownCompiler = await api.rolldown(input);
+    const rolldownOutput = await rolldownCompiler.generate();
+    const chunk = rolldownOutput.output[0];
+    if (!chunk || !('code' in chunk)) return undefined;
+
+    const result = await getCompileResult(
+      chunk.code,
+      chunk.imports,
+      chunk.dynamicImports,
+      chunk.moduleIds,
+      options.input,
+    );
+    const duration = Date.now() - startTime;
+
+    return result ? { ...result, duration } : undefined;
+  }
+
+  function compileWatch(options: CompileOptions, watchOptions: WatchOptions): ReturnType<RolldownApi['watch']> {
+    const rolldownInput = getRolldownInput(options);
+    const watcher = api.watch({
+      ...rolldownInput,
+      watch: {
+        skipWrite: true,
+        include: options.include,
+        exclude: options.exclude,
+      },
+    });
+
+    watcher.on('event', (event: RolldownWatcherEvent) => {
+      void (async () => {
+        if (event.code === 'ERROR') {
+          watchOptions.onChange(undefined, event, event.error);
+          return;
+        }
+
+        if (event.code !== 'BUNDLE_END') return;
+
+        const startTime = Date.now();
+        const bundle = event.result as
+          | {
+              generate?(): Promise<{
+                output: Array<{ code: string; imports: string[]; dynamicImports: string[]; moduleIds: string[] }>;
+              }>;
+              close(): Promise<void>;
+            }
+          | undefined;
+
+        try {
+          let result: CompileResult | undefined;
+          if (bundle && typeof bundle.generate === 'function') {
+            const output = await bundle.generate();
+            const chunk = output.output[0];
+            await bundle.close();
+            if (chunk && 'code' in chunk) {
+              result = await getCompileResult(
+                chunk.code,
+                chunk.imports,
+                chunk.dynamicImports,
+                chunk.moduleIds,
+                options.input,
+              );
+            }
+          } else {
+            if (bundle) await bundle.close();
+            result = await compile(options);
+          }
+
+          if (!result) {
+            watchOptions.onChange(undefined, event);
+            return;
+          }
+
+          watchOptions.onChange(
+            {
+              ...result,
+              duration: Date.now() - startTime + (event.duration ?? 0),
+            },
+            event,
+          );
+        } catch (err) {
+          if (bundle && typeof (bundle as { close?: () => Promise<void> }).close === 'function') {
+            await (bundle as { close(): Promise<void> }).close().catch(() => {
+              /* noop */
+            });
+          }
+          watchOptions.onChange(undefined, event, err);
+        }
+      })();
+    });
+
+    return watcher;
+  }
+
+  return { compile, compileWatch };
+}

--- a/packages/compiler/src/compiler.ts
+++ b/packages/compiler/src/compiler.ts
@@ -1,7 +1,11 @@
-import type { InputOptions } from '@rolldown/browser';
-import { rolldown } from '@rolldown/browser';
+import type { CompileOptions, CompileResult } from './types';
 
-import type { CompileOptions, CompileResult } from '.';
+/** Minimal rolldown input shape; compatible with both 'rolldown' and '@rolldown/browser'. */
+export interface RolldownInput {
+  input: string;
+  cwd: string;
+  plugins: unknown[];
+}
 
 /** Base64-encode UTF-8 string; works in Node (Buffer) and browser (TextEncoder + btoa). */
 function toBase64Utf8(str: string): string {
@@ -75,11 +79,21 @@ export function getRolldownInput(options: CompileOptions) {
     input,
     cwd,
     plugins: [...virtualSourcePlugin, createSurimiTransformPlugin(effectiveInclude, options.exclude)],
-  } satisfies InputOptions;
+  };
 }
 
-export async function getRolldownInstance(input: InputOptions) {
-  return rolldown(input);
+/** Matches data: URLs in error messages and stack traces so we can replace with source path. */
+const DATA_URL_PATTERN = /data:text\/javascript;base64,[A-Za-z0-9+/=]+/g;
+
+function rewriteDataUrlInError(error: Error, sourcePath: string): Error {
+  const message = error.message.replace(DATA_URL_PATTERN, sourcePath);
+  const stack = error.stack?.replace(DATA_URL_PATTERN, sourcePath);
+  const rewritten = new Error(message);
+  rewritten.name = error.name;
+  if (stack) rewritten.stack = stack;
+  if (error.cause)
+    rewritten.cause = error.cause instanceof Error ? rewriteDataUrlInError(error.cause, sourcePath) : error.cause;
+  return rewritten;
 }
 
 /**
@@ -92,8 +106,9 @@ export async function getCompileResult(
   imports: string[],
   dynamicImports: string[],
   moduleIds: string[],
+  sourcePath?: string,
 ): Promise<CompileResult | undefined> {
-  const { css, js } = await execute(code);
+  const { css, js } = await execute(code, sourcePath);
 
   // Extract all imported modules as watch files
   const watchFiles = getModuleDependencies(imports, dynamicImports, moduleIds);
@@ -109,11 +124,17 @@ export async function getCompileResult(
 /**
  * Executes the compiled Surimi code in a data URL module context
  * and extracts the generated CSS and preserved exports.
+ * When sourcePath is provided, errors are rewritten to show it instead of the data: URL.
  */
-export async function execute(code: string) {
+export async function execute(code: string, sourcePath?: string) {
   try {
-    const module = (await /* @vite-ignore */ import(
-      `data:text/javascript;base64,${toBase64Utf8(code)}`
+    // Dynamic import with variable URL so Vite (and other bundlers) don't try to pre-bundle this data URL
+    const dataUrl = `data:text/javascript;base64,${toBase64Utf8(code)}`;
+    const module = (await import(
+      // TODO: Fix this. We need to preserve the vite-ignore comment so this import isn't flagged
+      // by vite, as it cannot be analyzed. @preserve doesn't work for some reason.
+      //! @vite-ignore
+      dataUrl
     )) as SurimiModule;
 
     // Get the generated CSS
@@ -145,14 +166,22 @@ export async function execute(code: string) {
     return { css, js };
   } catch (error) {
     if (error instanceof Error) {
-      const message = error.message || String(error);
-      if (message.includes('from "data:')) {
-        // We suppress the ugly data URL in the error message
-        const strippedMessage = message.replace(/("data:[^ ]+)/g, '<surimi-module>');
-        throw new Error(`Failed to build surimi output: ${strippedMessage}`);
+      if (sourcePath) {
+        throw rewriteDataUrlInError(error, sourcePath);
       }
+      const message = error.message || String(error);
+      if (message.includes('data:') || message.includes('from "data:')) {
+        const strippedMessage = message
+          .replace(DATA_URL_PATTERN, '<surimi-module>')
+          .replace(/("data:[^"]*")/g, '<surimi-module>');
+        throw new Error(
+          strippedMessage.includes('Failed to build')
+            ? strippedMessage
+            : `Failed to build surimi output: ${strippedMessage}`,
+        );
+      }
+      throw error;
     }
-
     throw error;
   }
 }

--- a/packages/compiler/src/index.browser.ts
+++ b/packages/compiler/src/index.browser.ts
@@ -1,0 +1,12 @@
+import type { RolldownWatcher, RolldownWatcherEvent } from '@rolldown/browser';
+import { rolldown, watch } from '@rolldown/browser';
+
+import { createCompile, type RolldownApi } from './compile-api';
+import type { CompileOptions, CompileResult, WatchOptions } from './types';
+
+const { compile, compileWatch } = createCompile({ rolldown, watch } as RolldownApi);
+
+export type { CompileOptions, CompileResult, WatchOptions };
+export type { RolldownWatcher, RolldownWatcherEvent };
+
+export { compile, compileWatch };

--- a/packages/compiler/src/index.node.ts
+++ b/packages/compiler/src/index.node.ts
@@ -1,0 +1,12 @@
+import type { RolldownWatcher, RolldownWatcherEvent } from 'rolldown';
+import { rolldown, watch } from 'rolldown';
+
+import { createCompile, type RolldownApi } from './compile-api';
+import type { CompileOptions, CompileResult, WatchOptions } from './types';
+
+const { compile, compileWatch } = createCompile({ rolldown, watch } as RolldownApi);
+
+export type { CompileOptions, CompileResult, WatchOptions };
+export type { RolldownWatcher, RolldownWatcherEvent };
+
+export { compile, compileWatch };

--- a/packages/compiler/src/index.ts
+++ b/packages/compiler/src/index.ts
@@ -1,110 +1,13 @@
-import type { RolldownOutput, RolldownWatcher, RolldownWatcherEvent } from '@rolldown/browser';
-import { watch } from '@rolldown/browser';
-
-import { getCompileResult, getRolldownInput, getRolldownInstance } from '#compiler';
-
-/** Watch BUNDLE_END result: has generate() and close() per rolldown docs; BindingWatcherBundler .d.mts only declares close(). */
-interface WatchBundleResult {
-  generate(): Promise<RolldownOutput>;
-  close(): Promise<void>;
-}
-
-export interface CompileOptions {
-  /** Absolute path to the input file (or virtual entry path when `source` is provided). */
-  input: string;
-  /** Working directory for resolving modules. */
-  cwd: string;
-  /** Glob patterns for files to include in compilation */
-  include: string[];
-  /** Glob patterns for files to exclude from compilation */
-  exclude: string[];
-  /**
-   * Inline source code to compile instead of reading `input` from disk.
-   * When provided, `input` is used as the virtual module ID for resolving relative imports.
-   */
-  source?: string;
-}
-
-export interface WatchOptions {
-  /**
-   * Callback invoked when a file changes
-   * Receives the changed file ID, the type of event, and the latest compile result
-   * The compileResult can be undefined if the compilation failed, or if there is no output (file was deleted etc.)
-   */
-  onChange: (compileResult: CompileResult | undefined, event: RolldownWatcherEvent) => void;
-}
-
-export interface CompileResult {
-  /** The generated CSS output */
-  css: string;
-  /** The transformed JavaScript with preserved, JSON-serialized exports (Surimi runtime removed) */
-  js: string;
-  /** List of file dependencies. Can be used for HMR, watch mode etc. */
-  dependencies: string[];
-  /** Duration of the compilation in milliseconds */
-  duration: number;
-}
-
-export async function compile(options: CompileOptions): Promise<CompileResult | undefined> {
-  const startTime = Date.now();
-  const rolldownInput = getRolldownInput(options);
-  // Rolldown nicely provides an `asyncDispose` symbol. However, disposing the compiler at the end here when using rolldown-based vite
-  // will halt the build process indefinitely. TODO: Figure out how we can nicely dispose the compiler if it's not needed anymore.
-  // await using rolldownCompiler = await getRolldownInstance(rolldownInput);
-  const rolldownCompiler = await getRolldownInstance(rolldownInput);
-  const rolldownOutput = await rolldownCompiler.generate();
-  const chunk = rolldownOutput.output[0];
-
-  const result = await getCompileResult(chunk.code, chunk.imports, chunk.dynamicImports, chunk.moduleIds);
-  const duration = Date.now() - startTime;
-
-  return result ? { ...result, duration } : undefined;
-}
-
 /**
- * Performs the compilation and sets up a file watcher to recompile on changes.
- *
- * `watchOptions.onChange` is called whenever a file changes, with the new compilation result.
- *
- * @returns The Rolldown watcher instance for further handling.
+ * Default entry: Node (uses native `rolldown` for CLI and watch).
+ * For browser/WASM use the "browser" export: @surimi/compiler/browser
  */
-export function compileWatch(options: CompileOptions, watchOptions: WatchOptions): RolldownWatcher {
-  const rolldownInput = getRolldownInput(options);
-  const watcher = watch({
-    ...rolldownInput,
-    watch: {
-      skipWrite: true,
-      include: options.include,
-      exclude: options.exclude,
-    },
-  });
-
-  watcher.on('event', async event => {
-    if (event.code !== 'BUNDLE_END') return;
-
-    const startTime = Date.now();
-    const bundle = event.result as unknown as WatchBundleResult;
-    const output = await bundle.generate();
-
-    const chunk = output.output[0];
-
-    const result = await getCompileResult(chunk.code, chunk.imports, chunk.dynamicImports, chunk.moduleIds);
-
-    await bundle.close();
-
-    if (!result) {
-      watchOptions.onChange(undefined, event);
-      return;
-    }
-
-    watchOptions.onChange(
-      {
-        ...result,
-        duration: Date.now() - startTime + event.duration,
-      },
-      event,
-    );
-  });
-
-  return watcher;
-}
+export {
+  compile,
+  compileWatch,
+  type CompileOptions,
+  type CompileResult,
+  type WatchOptions,
+  type RolldownWatcher,
+  type RolldownWatcherEvent,
+} from './index.node';

--- a/packages/compiler/src/types.ts
+++ b/packages/compiler/src/types.ts
@@ -1,0 +1,42 @@
+/** Minimal watch event shape; compatible with both rolldown and @rolldown/browser. */
+export interface RolldownWatcherEvent {
+  code: string;
+  result?: unknown;
+  duration?: number;
+  error?: Error;
+}
+
+export interface CompileOptions {
+  /** Absolute path to the input file (or virtual entry path when `source` is provided). */
+  input: string;
+  /** Working directory for resolving modules. */
+  cwd: string;
+  /** Glob patterns for files to include in compilation */
+  include: string[];
+  /** Glob patterns for files to exclude from compilation */
+  exclude: string[];
+  /**
+   * Inline source code to compile instead of reading `input` from disk.
+   * When provided, `input` is used as the virtual module ID for resolving relative imports.
+   */
+  source?: string;
+}
+
+export interface WatchOptions {
+  /**
+   * Callback invoked when a file changes
+   * Receives the compile result (undefined on failure), the event, and optionally the error when compilation failed.
+   */
+  onChange: (compileResult: CompileResult | undefined, event: RolldownWatcherEvent, error?: unknown) => void;
+}
+
+export interface CompileResult {
+  /** The generated CSS output */
+  css: string;
+  /** The transformed JavaScript with preserved, JSON-serialized exports (Surimi runtime removed) */
+  js: string;
+  /** List of file dependencies. Can be used for HMR, watch mode etc. */
+  dependencies: string[];
+  /** Duration of the compilation in milliseconds */
+  duration: number;
+}

--- a/packages/compiler/test/unit/watch.spec.ts
+++ b/packages/compiler/test/unit/watch.spec.ts
@@ -1,8 +1,7 @@
 import path from 'node:path';
-import type { RolldownWatcher } from '@rolldown/browser';
 import { afterEach, describe, expect, it } from 'vitest';
 
-import { compileWatch } from '../../src';
+import { compileWatch, type RolldownWatcher } from '../../src';
 
 const fixturesDir = path.resolve(__dirname, '../fixtures');
 
@@ -35,6 +34,7 @@ describe('Compiler Watch Mode', () => {
       watcher = compileWatch(createOptions('simple.css.ts'), createWatchOptions());
 
       expect(watcher).toBeDefined();
+      if (!watcher) return;
       expect(watcher).toHaveProperty('on');
       expect(watcher).toHaveProperty('close');
       expect(typeof watcher.on).toBe('function');

--- a/packages/compiler/tsdown.config.ts
+++ b/packages/compiler/tsdown.config.ts
@@ -1,10 +1,19 @@
 import { defineConfig } from 'tsdown';
 
 export default defineConfig({
-  entry: ['src/index.ts', 'src/cli.ts'],
+  entry: {
+    'index.node': 'src/index.node.ts',
+    'index.browser': 'src/index.browser.ts',
+    cli: 'src/cli.ts',
+  },
   format: 'esm',
   platform: 'neutral',
   target: 'esnext',
   clean: true,
   dts: true,
+  outputOptions: {
+    legalComments: 'inline',
+  },
+  // Node entry uses 'rolldown'; browser entry uses '@rolldown/browser'. Each consumer loads only one.
+  external: ['rolldown', '@rolldown/browser'],
 });

--- a/packages/docs/astro.config.ts
+++ b/packages/docs/astro.config.ts
@@ -73,7 +73,6 @@ export default defineConfig({
 
   vite: {
     plugins: [
-      // @ts-expect-error errors here are because we use vite 8 already for the vite plugin, but not for astro.
       surimiPlugin(),
       vitePluginBundleSurimi(),
       nodePolyfills({

--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -19,7 +19,7 @@
   },
   "dependencies": {
     "@monaco-editor/react": "^4.7.0",
-    "@rolldown/browser": "1.0.0-rc.5",
+    "@rolldown/browser": "1.0.0-rc.9",
     "@surimi/compiler": "workspace:*",
     "clsx": "^2.1.1",
     "fancy-ansi": "^0.1.3",

--- a/packages/docs/src/content.config.ts
+++ b/packages/docs/src/content.config.ts
@@ -1,5 +1,6 @@
-import { defineCollection, z } from 'astro:content';
+import { defineCollection } from 'astro:content';
 import { glob } from 'astro/loaders';
+import { z } from 'astro/zod';
 
 const docsCategories = ['gettingStarted', 'guides', 'apiReference'] as const;
 

--- a/packages/docs/src/playground/components/Editor/CodeEditor.tsx
+++ b/packages/docs/src/playground/components/Editor/CodeEditor.tsx
@@ -51,9 +51,13 @@ export default function CodeEditor({
   useEffect(() => {
     setTheme(getMonacoThemeName());
     const el = document.documentElement;
-    const observer = new MutationObserver(() => setTheme(getMonacoThemeName()));
+    const observer = new MutationObserver(() => {
+      setTheme(getMonacoThemeName());
+    });
     observer.observe(el, { attributes: true, attributeFilter: ['data-theme'] });
-    return () => observer.disconnect();
+    return () => {
+      observer.disconnect();
+    };
   }, []);
 
   useEffect(() => {

--- a/packages/docs/src/playground/components/LectureContent/LectureContent.tsx
+++ b/packages/docs/src/playground/components/LectureContent/LectureContent.tsx
@@ -6,8 +6,8 @@ export interface LectureContentProps {
   contentHtml: string;
   currentIndex: number;
   totalLectures: number;
-  onPrevious: () => void;
-  onNext: () => void;
+  onPrevious?: (() => void) | undefined;
+  onNext?: (() => void) | undefined;
 }
 
 export default function LectureContent({

--- a/packages/docs/src/playground/components/Playground/Playground.tsx
+++ b/packages/docs/src/playground/components/Playground/Playground.tsx
@@ -4,7 +4,7 @@ import { useCallback, useEffect, useState } from 'react';
 import { Panel, PanelGroup, PanelResizeHandle } from 'react-resizable-panels';
 import surimiCode from 'surimi?bundle';
 
-import { compile, type CompileResult } from '@surimi/compiler';
+import { compile, type CompileResult } from '@surimi/compiler/browser';
 
 import CodeEditor from '#playground/components/Editor/CodeEditor';
 import HtmlCssView from '#playground/components/HtmlCssView/HtmlCssView';
@@ -46,7 +46,6 @@ function initFs() {
 
 const ENTRY_FILE = 'index.css.ts';
 const MOBILE_BREAKPOINT = 768;
-const noop = () => {};
 
 type MobileView = 'lecture' | 'editor' | 'output';
 
@@ -94,10 +93,14 @@ export default function Playground({ lectures, initialLectureId }: PlaygroundPro
   // Mobile layout: single view + tabs below MOBILE_BREAKPOINT
   useEffect(() => {
     const mql = window.matchMedia(`(max-width: ${MOBILE_BREAKPOINT}px)`);
-    const handler = () => setIsMobile(mql.matches);
+    const handler = () => {
+      setIsMobile(mql.matches);
+    };
     handler();
     mql.addEventListener('change', handler);
-    return () => mql.removeEventListener('change', handler);
+    return () => {
+      mql.removeEventListener('change', handler);
+    };
   }, []);
 
   // When user uses browser back/forward, sync state from URL
@@ -196,8 +199,20 @@ export default function Playground({ lectures, initialLectureId }: PlaygroundPro
       contentHtml={currentLecture.contentHtml}
       currentIndex={currentLectureIndex}
       totalLectures={lectures.length}
-      onPrevious={currentLectureIndex > 0 ? () => goToLecture(currentLectureIndex - 1) : noop}
-      onNext={currentLectureIndex < lectures.length - 1 ? () => goToLecture(currentLectureIndex + 1) : noop}
+      onPrevious={
+        currentLectureIndex > 0
+          ? () => {
+              goToLecture(currentLectureIndex - 1);
+            }
+          : undefined
+      }
+      onNext={
+        currentLectureIndex < lectures.length - 1
+          ? () => {
+              goToLecture(currentLectureIndex + 1);
+            }
+          : undefined
+      }
     />
   );
 
@@ -210,7 +225,9 @@ export default function Playground({ lectures, initialLectureId }: PlaygroundPro
               key={path}
               type="button"
               className={`surimi-playground__editor-tab ${path === selectedFile ? 'surimi-playground__editor-tab--active' : ''}`}
-              onClick={() => handleTabSelect(path)}
+              onClick={() => {
+                handleTabSelect(path);
+              }}
             >
               {path.replace(/^\//, '')}
             </button>
@@ -243,7 +260,9 @@ export default function Playground({ lectures, initialLectureId }: PlaygroundPro
             role="tab"
             aria-selected={activeMobileView === 'lecture'}
             className={`surimi-playground__mobile-tab ${activeMobileView === 'lecture' ? 'surimi-playground__mobile-tab--active' : ''}`}
-            onClick={() => setActiveMobileView('lecture')}
+            onClick={() => {
+              setActiveMobileView('lecture');
+            }}
           >
             Lecture
           </button>
@@ -252,7 +271,9 @@ export default function Playground({ lectures, initialLectureId }: PlaygroundPro
             role="tab"
             aria-selected={activeMobileView === 'editor'}
             className={`surimi-playground__mobile-tab ${activeMobileView === 'editor' ? 'surimi-playground__mobile-tab--active' : ''}`}
-            onClick={() => setActiveMobileView('editor')}
+            onClick={() => {
+              setActiveMobileView('editor');
+            }}
           >
             Code
           </button>
@@ -261,7 +282,9 @@ export default function Playground({ lectures, initialLectureId }: PlaygroundPro
             role="tab"
             aria-selected={activeMobileView === 'output'}
             className={`surimi-playground__mobile-tab ${activeMobileView === 'output' ? 'surimi-playground__mobile-tab--active' : ''}`}
-            onClick={() => setActiveMobileView('output')}
+            onClick={() => {
+              setActiveMobileView('output');
+            }}
           >
             Output
           </button>
@@ -285,7 +308,7 @@ export default function Playground({ lectures, initialLectureId }: PlaygroundPro
 
           <PanelResizeHandle className="surimi-playground__resize-handle" />
 
-          <Panel defaultSize={55} minSize={30} maxSize={60}>
+          <Panel defaultSize={50} minSize={30} maxSize={60}>
             {editorContent}
           </Panel>
 

--- a/packages/docs/src/utils/theme.ts
+++ b/packages/docs/src/utils/theme.ts
@@ -3,6 +3,7 @@ export const THEME_STORAGE_KEY = 'theme';
 export type Theme = 'light' | 'dark';
 
 function isLocalStorageAvailable(): boolean {
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- untrue. Depends on the browser/node
   return typeof window !== 'undefined' && 'localStorage' in window && window.localStorage != null;
 }
 
@@ -12,6 +13,7 @@ export function getTheme(): Theme {
     const stored = localStorage.getItem(THEME_STORAGE_KEY);
     if (stored === 'light' || stored === 'dark') return stored;
   }
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- untrue. Depends on the browser/node
   if (typeof window !== 'undefined' && window.matchMedia) {
     return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
   }
@@ -33,9 +35,17 @@ export function toggleTheme(): Theme {
 }
 
 export function watchPreferredColorScheme(callback: (theme: Theme) => void): () => void {
-  if (typeof window === 'undefined' || !window.matchMedia) return () => {};
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- untrue. Depends on the browser/node
+  if (typeof window === 'undefined' || !window.matchMedia)
+    return () => {
+      /* noop */
+    };
   const mql = window.matchMedia('(prefers-color-scheme: dark)');
-  const handler = () => callback(mql.matches ? 'dark' : 'light');
+  const handler = () => {
+    callback(mql.matches ? 'dark' : 'light');
+  };
   mql.addEventListener('change', handler);
-  return () => mql.removeEventListener('change', handler);
+  return () => {
+    mql.removeEventListener('change', handler);
+  };
 }

--- a/packages/docs/src/utils/view-transition.ts
+++ b/packages/docs/src/utils/view-transition.ts
@@ -10,7 +10,7 @@ const KEYFRAME_COUNT = 20;
 
 function wavyCirclePath(cx: number, cy: number, radius: number): string {
   const total = LOBES * POINTS_PER_LOBE;
-  const pts: [number, number][] = [];
+  const pts: Array<[number, number]> = [];
   for (let i = 0; i < total; i++) {
     const angle = (i / total) * Math.PI * 2;
     const lobe = Math.sin(LOBES * angle);
@@ -78,5 +78,7 @@ export function withViewTransition(triggerEl: HTMLElement | null, apply: () => v
     .then(() => {
       animateWavyReveal(cx, cy, '::view-transition-new(root)', 500);
     })
-    .catch(() => {});
+    .catch(() => {
+      /* noop */
+    });
 }

--- a/packages/vite-plugin-surimi/src/utils.ts
+++ b/packages/vite-plugin-surimi/src/utils.ts
@@ -30,7 +30,7 @@ function vlqEncode(n: number): string {
     let digit = n & 31;
     n >>>= 5;
     if (n > 0) digit |= 32;
-    encoded += VLQ_BASE64[digit];
+    encoded += VLQ_BASE64[digit] ?? '';
   } while (n > 0);
   return encoded;
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -413,11 +413,17 @@ importers:
         specifier: ^0.11.0
         version: 0.11.0
       '@rolldown/browser':
-        specifier: 1.0.0-rc.5
-        version: 1.0.0-rc.5
+        specifier: 1.0.0-rc.9
+        version: 1.0.0-rc.9
       commander:
         specifier: ^14.0.3
         version: 14.0.3
+      picocolors:
+        specifier: ^1.1.1
+        version: 1.1.1
+      rolldown:
+        specifier: 1.0.0-rc.9
+        version: 1.0.0-rc.9
       surimi:
         specifier: workspace:*
         version: link:../surimi
@@ -503,8 +509,8 @@ importers:
         specifier: ^4.7.0
         version: 4.7.0(monaco-editor@0.55.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@rolldown/browser':
-        specifier: 1.0.0-rc.5
-        version: 1.0.0-rc.5
+        specifier: 1.0.0-rc.9
+        version: 1.0.0-rc.9
       '@surimi/compiler':
         specifier: workspace:*
         version: link:../compiler
@@ -2451,8 +2457,8 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@rolldown/browser@1.0.0-rc.5':
-    resolution: {integrity: sha512-u7jPxa90kMYSZ8R9pjGw6lcFSkFgZdumC6Ir5yiLp1HqFy+ShvZwuwazL+w4L5rKlpHMMXT8sy6ZA+jOlbWG5Q==}
+  '@rolldown/browser@1.0.0-rc.9':
+    resolution: {integrity: sha512-McXuGuA0eMUfFu1zxrwWXG/A6eGIZmLikLUsxelKbDyFzPzmmsi55rlciwSQ5FcJw3jBlLHDWBz/9BWyZGO2aw==}
     hasBin: true
 
   '@rolldown/pluginutils@1.0.0-beta.45':
@@ -8999,7 +9005,7 @@ snapshots:
   '@rolldown/binding-win32-x64-msvc@1.0.0-rc.9':
     optional: true
 
-  '@rolldown/browser@1.0.0-rc.5':
+  '@rolldown/browser@1.0.0-rc.9':
     dependencies:
       '@napi-rs/wasm-runtime': 1.1.1
 


### PR DESCRIPTION
This fixes a bunch of issues we had with the compiler and the CLI, improves the cli look/feel and error  handling.
Most importantly, it fixes the watch mode of the CLI which is broken since we switched to @rolldown/browser.

The reason for that is simply that `@rolldown/browser` doesn't seem to have watch mode support in node environments, probably because it lacks WASI support. There are some open issues for this like https://github.com/rolldown/rolldown/issues/898. 

For now, we just build two versions of the compiler: A base version with rolldown and a `/browser` version with rolldown/browser. That seems to work well, but does make some things more complicated. Playground works, which is the most important thing for now. I put both as peerDeps, which might not be ideal but let's see