### PR TITLE
feat: export vite plugin from surimi package

### DIFF
--- a/examples/nuxt/nuxt.config.ts
+++ b/examples/nuxt/nuxt.config.ts
@@ -1,4 +1,4 @@
-import surimiPlugin from 'vite-plugin-surimi';
+import surimiPlugin from 'surimi/vite';
 
 // https://nuxt.com/docs/api/configuration/nuxt-config
 export default defineNuxtConfig({

--- a/examples/nuxt/package.json
+++ b/examples/nuxt/package.json
@@ -15,7 +15,6 @@
   },
   "devDependencies": {
     "@surimi/typescript-config": "workspace:*",
-    "surimi": "workspace:*",
-    "vite-plugin-surimi": "workspace:*"
+    "surimi": "workspace:*"
   }
 }

--- a/examples/vite-react/package.json
+++ b/examples/vite-react/package.json
@@ -27,7 +27,6 @@
     "@types/react-dom": "^19.2.3",
     "surimi": "workspace:*",
     "vite": "catalog:build",
-    "vite-bundle-analyzer": "catalog:utils",
-    "vite-plugin-surimi": "workspace:*"
+    "vite-bundle-analyzer": "catalog:utils"
   }
 }

--- a/examples/vite-react/vite.config.ts
+++ b/examples/vite-react/vite.config.ts
@@ -1,6 +1,6 @@
+import surimiPlugin from 'surimi/vite';
 import { defineConfig } from 'vite';
 import { analyzer } from 'vite-bundle-analyzer';
-import surimiPlugin from 'vite-plugin-surimi';
 
 export default defineConfig(() => {
   return {

--- a/examples/vite-simple/package.json
+++ b/examples/vite-simple/package.json
@@ -12,7 +12,6 @@
     "@surimi/typescript-config": "workspace:*",
     "surimi": "workspace:*",
     "vite": "catalog:build",
-    "vite-bundle-analyzer": "catalog:utils",
-    "vite-plugin-surimi": "workspace:*"
+    "vite-bundle-analyzer": "catalog:utils"
   }
 }

--- a/examples/vite-simple/vite.config.ts
+++ b/examples/vite-simple/vite.config.ts
@@ -1,6 +1,6 @@
+import surimi from 'surimi/vite';
 import { defineConfig } from 'vite';
 import { analyzer } from 'vite-bundle-analyzer';
-import surimi from 'vite-plugin-surimi';
 
 export default defineConfig(() => {
   return {

--- a/examples/vite-vanilla/package.json
+++ b/examples/vite-vanilla/package.json
@@ -11,7 +11,6 @@
   "devDependencies": {
     "@surimi/typescript-config": "workspace:*",
     "surimi": "workspace:*",
-    "vite": "catalog:build",
-    "vite-plugin-surimi": "workspace:*"
+    "vite": "catalog:build"
   }
 }

--- a/examples/vite-vanilla/vite.config.ts
+++ b/examples/vite-vanilla/vite.config.ts
@@ -1,5 +1,5 @@
+import surimi from 'surimi/vite';
 import { defineConfig } from 'vite';
-import surimi from 'vite-plugin-surimi';
 
 export default defineConfig(() => {
   return {

--- a/examples/waku/package.json
+++ b/examples/waku/package.json
@@ -21,7 +21,6 @@
     "@vitejs/plugin-react": "^6.0.2",
     "babel-plugin-react-compiler": "^1.0.0",
     "typescript": "^6.0.3",
-    "vite": "8.0.16",
-    "vite-plugin-surimi": "workspace:*"
+    "vite": "8.0.16"
   }
 }

--- a/examples/waku/waku.config.ts
+++ b/examples/waku/waku.config.ts
@@ -1,5 +1,5 @@
 import react from '@vitejs/plugin-react';
-import surimiPlugin from 'vite-plugin-surimi';
+import surimiPlugin from 'surimi/vite';
 import { defineConfig } from 'waku/config';
 
 export default defineConfig({

--- a/packages/docs/astro.config.ts
+++ b/packages/docs/astro.config.ts
@@ -4,9 +4,9 @@ import { defineConfig, passthroughImageService } from 'astro/config';
 import remarkEmoji from 'remark-emoji';
 import remarkGithub from 'remark-github';
 import blockquoteAlert from 'remark-github-blockquote-alert';
+import surimiPlugin from 'surimi/vite';
 import { build, type Plugin, type Rollup } from 'vite';
 import { nodePolyfills } from 'vite-plugin-node-polyfills';
-import surimiPlugin from 'vite-plugin-surimi';
 
 function vitePluginBundleSurimi() {
   async function bundleToString(entry: string) {

--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -59,7 +59,6 @@
     "surimi": "workspace:*",
     "typescript": "catalog:build",
     "vite": "8.0.16",
-    "vite-plugin-node-polyfills": "^0.28.0",
-    "vite-plugin-surimi": "workspace:*"
+    "vite-plugin-node-polyfills": "^0.28.0"
   }
 }

--- a/packages/docs/src/pages/docs/getting-started.mdx
+++ b/packages/docs/src/pages/docs/getting-started.mdx
@@ -35,28 +35,20 @@ If you use any vite based tool like Astro, Vue, Nuxt or use Vite with React etc.
 For more options, have a look at our [Guides Overview](/docs/guides/overview). Vite is NOT required for Surimi, but it's the easiest way to get started.
 More on that in a bit.
 
-### Installation of the Vite plugin
+### Adding the Vite plugin
 
-```bash
-npm install -D vite-plugin-surimi
-# or
-yarn add -D vite-plugin-surimi
-# or
-pnpm add -D vite-plugin-surimi
-```
-
-Note that both `surimi` and the vite plugin are installed as dev dependencies, as they have zero runtime.
-
-Now, add the plugin to your `vite.config.ts`:
+The Vite plugin ships with `surimi` itself, so there's nothing extra to install. Just import it from `surimi/vite` and add it to your `vite.config.ts`:
 
 ```ts
 import { defineConfig } from 'vite';
-import surimi from 'vite-plugin-surimi';
+import surimi from 'surimi/vite';
 
 export default defineConfig({
   plugins: [surimi()],
 });
 ```
+
+Note that `surimi` is installed as a dev dependency, as it has zero runtime.
 
 For more details on the vite plugin see [Using Surimi with Vite](/docs/guides/vite).
 

--- a/packages/docs/src/pages/docs/guides/vite.mdx
+++ b/packages/docs/src/pages/docs/guides/vite.mdx
@@ -7,17 +7,17 @@ layout: "#layouts/Docs/Docs.astro"
 
 # Using Surimi with Vite
 
-To use surimi with Vite, in addition to `surimi`, you need to install the `vite-plugin-surimi` plugin and add it to your Vite configuration.
+Surimi's Vite plugin ships with `surimi`. just import it from `surimi/vite`.
 
 ```bash
-pnpm install -D surimi vite-plugin-surimi
+pnpm install -D surimi
 ```
 
 Then, update your `vite.config.ts` file to include the plugin:
 
 ```ts title="vite.config.ts"
 import { defineConfig } from 'vite';
-import surimi from 'vite-plugin-surimi';
+import surimi from 'surimi/vite';
 
 export default defineConfig({
   plugins: [surimi()],

--- a/packages/docs/src/pages/docs/how-it-works.mdx
+++ b/packages/docs/src/pages/docs/how-it-works.mdx
@@ -92,7 +92,7 @@ Let's go through how surimi works, when using the vite plugin (the recommended w
 
 1. The user writes a `.css.ts` file, using Surimi
 2. The file is imported into the project, e.g. in a component
-3. Vite resolves the file, calling `vite-plugin-surimi` to handle the import.
+3. Vite resolves the file, calling the Surimi Vite plugin (`surimi/vite`) to handle the import.
 4. Surimi determines if the file should be compiled, read from cache etc.
    4.1. It also handles SSR, inlining, cache invalidation, HMR etc.
 5. The compiler loads the file (and it's imports) using [rolldown](https://rolldown.rs/).

--- a/packages/docs/src/pages/docs/reference/vite-plugin-surimi.mdx
+++ b/packages/docs/src/pages/docs/reference/vite-plugin-surimi.mdx
@@ -1,10 +1,13 @@
 ---
-title: vite-plugin-surimi
+title: surimi/vite
 category: apiReference
 categoryOrderId: 20
 layout: "#layouts/Docs/Docs.astro"
 ---
 
-# `vite-plugin-surimi` API Reference
+# `surimi/vite` API Reference
 
 to be done. See [Using with vite](/docs/guides/vite) for now.
+
+The vite plugin is a wrapper around the `@surimi/compiler` package. It is used to compile `.css.ts` files into CSS.
+It's a default dependency of `surimi`, or you can install it via `pnpm add vite-plugin-surimi`.

--- a/packages/surimi/package.json
+++ b/packages/surimi/package.json
@@ -23,6 +23,10 @@
     "./conditional": {
       "types": "./dist/conditional.d.ts",
       "import": "./dist/conditional.js"
+    },
+    "./vite": {
+      "types": "./dist/vite.d.ts",
+      "import": "./dist/vite.js"
     }
   },
   "main": "dist/index.js",
@@ -45,12 +49,21 @@
     "@surimi/common": "workspace:*",
     "@surimi/conditional": "workspace:*",
     "@surimi/core": "workspace:*",
-    "@surimi/parsers": "workspace:*"
+    "@surimi/parsers": "workspace:*",
+    "vite-plugin-surimi": "workspace:*"
   },
   "devDependencies": {
     "@surimi/typescript-config": "workspace:*",
     "tsdown": "catalog:build",
     "typescript": "catalog:build",
     "vitest": "catalog:test"
+  },
+  "peerDependencies": {
+    "vite": "catalog:build"
+  },
+  "peerDependenciesMeta": {
+    "vite": {
+      "optional": true
+    }
   }
 }

--- a/packages/surimi/src/vite.ts
+++ b/packages/surimi/src/vite.ts
@@ -1,0 +1,2 @@
+export { default, default as surimiPlugin } from 'vite-plugin-surimi';
+export type { SurimiOptions } from 'vite-plugin-surimi';

--- a/packages/surimi/tsdown.config.ts
+++ b/packages/surimi/tsdown.config.ts
@@ -1,7 +1,7 @@
 import { defineConfig } from 'tsdown';
 
 export default defineConfig({
-  entry: ['src/index.ts', 'src/conditional.ts'],
+  entry: ['src/index.ts', 'src/conditional.ts', 'src/vite.ts'],
   format: ['esm'],
   target: 'esnext',
   platform: 'neutral',

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -186,9 +186,6 @@ importers:
       surimi:
         specifier: workspace:*
         version: link:../../packages/surimi
-      vite-plugin-surimi:
-        specifier: workspace:*
-        version: link:../../packages/vite-plugin-surimi
 
   examples/vite-react:
     dependencies:
@@ -220,9 +217,6 @@ importers:
       vite-bundle-analyzer:
         specifier: catalog:utils
         version: 1.3.8
-      vite-plugin-surimi:
-        specifier: workspace:*
-        version: link:../../packages/vite-plugin-surimi
 
   examples/vite-simple:
     devDependencies:
@@ -238,9 +232,6 @@ importers:
       vite-bundle-analyzer:
         specifier: catalog:utils
         version: 1.3.8
-      vite-plugin-surimi:
-        specifier: workspace:*
-        version: link:../../packages/vite-plugin-surimi
 
   examples/vite-vanilla:
     devDependencies:
@@ -253,9 +244,6 @@ importers:
       vite:
         specifier: catalog:build
         version: 8.0.16(@types/node@25.9.2)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0)
-      vite-plugin-surimi:
-        specifier: workspace:*
-        version: link:../../packages/vite-plugin-surimi
 
   examples/waku:
     dependencies:
@@ -293,9 +281,6 @@ importers:
       vite:
         specifier: 8.0.16
         version: 8.0.16(@types/node@25.9.2)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0)
-      vite-plugin-surimi:
-        specifier: workspace:*
-        version: link:../../packages/vite-plugin-surimi
 
   packages/ast:
     devDependencies:
@@ -538,9 +523,6 @@ importers:
       vite-plugin-node-polyfills:
         specifier: ^0.28.0
         version: 0.28.0(rollup@4.61.1)(vite@8.0.16(@types/node@25.9.2)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0))
-      vite-plugin-surimi:
-        specifier: workspace:*
-        version: link:../vite-plugin-surimi
 
   packages/parsers:
     devDependencies:
@@ -574,6 +556,12 @@ importers:
       '@surimi/parsers':
         specifier: workspace:*
         version: link:../parsers
+      vite:
+        specifier: catalog:build
+        version: 8.0.16(@types/node@25.9.2)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0)
+      vite-plugin-surimi:
+        specifier: workspace:*
+        version: link:../vite-plugin-surimi
     devDependencies:
       '@surimi/typescript-config':
         specifier: workspace:*


### PR DESCRIPTION
This simply adds the vite plugin as a dependency of surimi, so users can use it directly without another install. A bit inspired by how easy it is to use stuff with waku.

We might want to make it clear that this does not blow up the surimi package in size? Not a build dep of course.